### PR TITLE
Parse error details during onboarding and revoking processes

### DIFF
--- a/agrirouter-sdk-dotnet-standard-api/Dto/Onboard/OnboardError.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Dto/Onboard/OnboardError.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Agrirouter.Api.Dto.Onboard
+{
+    /// <summary>
+    ///     Data transfer object for the onboard and revoke error response.
+    /// </summary>
+    public class OnboardErrorResponse {
+        /// <summary>
+        ///     The error.
+        /// </summary>
+        [JsonProperty(PropertyName = "error")]
+        public OnboardError onboardError { get; set; }
+    }
+    /// <summary>
+    ///     Data transfer object for the onboard and revoke error.
+    /// </summary>
+    public class OnboardError
+    {
+        /// <summary>
+        ///     Error code.
+        /// </summary>
+        [JsonProperty(PropertyName = "code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        ///     Error Message.
+        /// </summary>
+        [JsonProperty(PropertyName = "message")]
+        public string Message { get; set; }
+
+        /// <summary>
+        ///     Error target.
+        /// </summary>
+        [JsonProperty(PropertyName = "target")]
+        public string Target { get; set; }
+
+        /// <summary>
+        ///     Error details.
+        /// </summary>
+        [JsonProperty(PropertyName = "details")]
+        public List<OnboardError> Details { get; set; }
+    }
+}

--- a/agrirouter-sdk-dotnet-standard-api/Dto/Onboard/OnboardError.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Dto/Onboard/OnboardError.cs
@@ -11,7 +11,7 @@ namespace Agrirouter.Api.Dto.Onboard
         ///     The error.
         /// </summary>
         [JsonProperty(PropertyName = "error")]
-        public OnboardError onboardError { get; set; }
+        public OnboardError OnboardError { get; set; }
     }
     /// <summary>
     ///     Data transfer object for the onboard and revoke error.

--- a/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotFetchMessagesException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotFetchMessagesException.cs
@@ -14,14 +14,11 @@ namespace Agrirouter.Api.Exception
         /// </summary>
         /// <param name="statusCode">-</param>
         /// <param name="errorMessage">-</param>
-        public CouldNotFetchMessagesException(HttpStatusCode statusCode, string errorMessage)
+        public CouldNotFetchMessagesException(HttpStatusCode statusCode, string errorMessage): base(errorMessage)
         {
             StatusCode = statusCode;
-            ErrorMessage = errorMessage;
         }
 
-        private HttpStatusCode StatusCode { get; }
-
-        private string ErrorMessage { get; }
+        public HttpStatusCode StatusCode { get; }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotFetchMessagesException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotFetchMessagesException.cs
@@ -13,7 +13,7 @@ namespace Agrirouter.Api.Exception
         ///     Constructor.
         /// </summary>
         /// <param name="statusCode">-</param>
-        /// <param name="errorMessage">-</param>
+        /// <param name="message">-</param>
         public CouldNotFetchMessagesException(HttpStatusCode statusCode, string message): base(message)
         {
             StatusCode = statusCode;

--- a/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotFetchMessagesException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotFetchMessagesException.cs
@@ -14,7 +14,7 @@ namespace Agrirouter.Api.Exception
         /// </summary>
         /// <param name="statusCode">-</param>
         /// <param name="errorMessage">-</param>
-        public CouldNotFetchMessagesException(HttpStatusCode statusCode, string errorMessage): base(errorMessage)
+        public CouldNotFetchMessagesException(HttpStatusCode statusCode, string message): base(message)
         {
             StatusCode = statusCode;
         }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotSendMqttMessageException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotSendMqttMessageException.cs
@@ -19,6 +19,6 @@ namespace Agrirouter.Api.Exception
             ReasonCode = reasonCode;
         }
 
-        private MqttClientPublishReasonCode ReasonCode { get; }
+        public MqttClientPublishReasonCode ReasonCode { get; }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/OnboardException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/OnboardException.cs
@@ -1,10 +1,10 @@
-using System;
 using System.Net;
+using Agrirouter.Api.Dto.Onboard;
 
 namespace Agrirouter.Api.Exception
 {
     /// <summary>
-    ///     Will be thrown if the onboarding process was not successful.
+    ///     Will be thrown if the onboarding or revoking processes are not successful.
     /// </summary>
     [Serializable]
     public class OnboardException : System.Exception
@@ -13,15 +13,15 @@ namespace Agrirouter.Api.Exception
         ///     Constructor.
         /// </summary>
         /// <param name="statusCode">-</param>
-        /// <param name="errorMessage">-</param>
-        public OnboardException(HttpStatusCode statusCode, string errorMessage)
+        /// <param name="onboardError">-</param>
+        public OnboardException(HttpStatusCode statusCode, OnboardError onboardError): base(onboardError.Message)
         {
             StatusCode = statusCode;
-            ErrorMessage = errorMessage;
+            Error = onboardError;
         }
 
         public HttpStatusCode StatusCode { get; }
 
-        public string ErrorMessage { get; }
+        public OnboardError Error { get; }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/OnboardException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/OnboardException.cs
@@ -1,27 +1,21 @@
+using System;
 using System.Net;
 using Agrirouter.Api.Dto.Onboard;
 
 namespace Agrirouter.Api.Exception
 {
     /// <summary>
-    ///     Will be thrown if the onboarding or revoking processes are not successful.
+    ///     Will be thrown if the onboarding process is not successful.
     /// </summary>
     [Serializable]
-    public class OnboardException : System.Exception
-    {
+    public class OnboardException : OnboardRevokeExceptionBase {
         /// <summary>
         ///     Constructor.
         /// </summary>
         /// <param name="statusCode">-</param>
         /// <param name="onboardError">-</param>
-        public OnboardException(HttpStatusCode statusCode, OnboardError onboardError): base(onboardError.Message)
+        public OnboardException(HttpStatusCode statusCode, OnboardError onboardError): base(statusCode, onboardError)
         {
-            StatusCode = statusCode;
-            Error = onboardError;
         }
-
-        public HttpStatusCode StatusCode { get; }
-
-        public OnboardError Error { get; }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/OnboardException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/OnboardException.cs
@@ -17,5 +17,14 @@ namespace Agrirouter.Api.Exception
         public OnboardException(HttpStatusCode statusCode, OnboardError onboardError): base(statusCode, onboardError)
         {
         }
+
+        /// <summary> 
+        ///     Constructor with error message only. 
+        /// </summary> 
+        /// <param name="statusCode">-</param> 
+        /// <param name="message">-</param> 
+        public OnboardException(HttpStatusCode statusCode, string message) : base(statusCode, message)
+        {
+        }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/OnboardRevokeExceptionBase.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/OnboardRevokeExceptionBase.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Net;
+using Agrirouter.Api.Dto.Onboard;
+
+namespace Agrirouter.Api.Exception
+{
+    /// <summary>
+    ///     Base exception class for errors during onboarding and revoking processes.
+    /// </summary>
+    [Serializable]
+    public class OnboardRevokeExceptionBase : System.Exception
+    {
+        /// <summary>
+        ///     Constructor.
+        /// </summary>
+        /// <param name="statusCode">-</param>
+        /// <param name="onboardError">-</param>
+        public OnboardRevokeExceptionBase(HttpStatusCode statusCode, OnboardError onboardError): base(onboardError.Message)
+        {
+            StatusCode = statusCode;
+            Error = onboardError;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+
+        public OnboardError Error { get; }
+    }
+}

--- a/agrirouter-sdk-dotnet-standard-api/Exception/OnboardRevokeExceptionBase.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/OnboardRevokeExceptionBase.cs
@@ -21,6 +21,19 @@ namespace Agrirouter.Api.Exception
             Error = onboardError;
         }
 
+        /// <summary>
+        ///     Constructor with error message only.
+        /// </summary>
+        /// <param name="statusCode">-</param>
+        /// <param name="message">-</param>
+        public OnboardRevokeExceptionBase(HttpStatusCode statusCode, string message): base(message)
+        {
+            StatusCode = statusCode;
+            Error = new OnboardError {
+                Message = message
+            };
+        }
+
         public HttpStatusCode StatusCode { get; }
 
         public OnboardError Error { get; }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/RevokeException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/RevokeException.cs
@@ -17,5 +17,14 @@ namespace Agrirouter.Api.Exception
         public RevokeException(HttpStatusCode statusCode, OnboardError onboardError): base(statusCode, onboardError)
         {
         }
+
+        /// <summary> 
+        ///     Constructor with error message only. 
+        /// </summary> 
+        /// <param name="statusCode">-</param> 
+        /// <param name="message">-</param> 
+        public RevokeException(HttpStatusCode statusCode, string message) : base(statusCode, message)
+        {
+        }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-api/Exception/RevokeException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/RevokeException.cs
@@ -1,25 +1,21 @@
+using System;
 using System.Net;
+using Agrirouter.Api.Dto.Onboard;
 
 namespace Agrirouter.Api.Exception
 {
     /// <summary>
-    ///     Will be thrown if the revoke is not successful.
+    ///     Will be thrown if the revoking process is not successful.
     /// </summary>
-    public class RevokeException : System.Exception
-    {
+    [Serializable]
+    public class RevokeException : OnboardRevokeExceptionBase {
         /// <summary>
         ///     Constructor.
         /// </summary>
         /// <param name="statusCode">-</param>
-        /// <param name="errorMessage">-</param>
-        public RevokeException(HttpStatusCode statusCode, string errorMessage)
+        /// <param name="onboardError">-</param>
+        public RevokeException(HttpStatusCode statusCode, OnboardError onboardError): base(statusCode, onboardError)
         {
-            StatusCode = statusCode;
-            ErrorMessage = errorMessage;
         }
-
-        private HttpStatusCode StatusCode { get; }
-
-        private string ErrorMessage { get; }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/OnboardService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/OnboardService.cs
@@ -66,12 +66,13 @@ namespace Agrirouter.Impl.Service.Onboard
                 new AuthenticationHeaderValue("Bearer", onboardParameters.RegistrationCode);
 
             var httpResponseMessage = _httpClient.SendAsync(httpRequestMessage).Result;
-
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                throw new OnboardException(httpResponseMessage.StatusCode,
-                    httpResponseMessage.Content.ReadAsStringAsync().Result);
-
             var result = httpResponseMessage.Content.ReadAsStringAsync().Result;
+
+            if (!httpResponseMessage.IsSuccessStatusCode) {
+                var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+            }
+
             var onboardingResponse = JsonConvert.DeserializeObject(result, typeof(OnboardResponse));
             return onboardingResponse as OnboardResponse;
         }
@@ -108,11 +109,13 @@ namespace Agrirouter.Impl.Service.Onboard
 
             var httpResponseMessage = await _httpClient.SendAsync(httpRequestMessage);
 
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                throw new OnboardException(httpResponseMessage.StatusCode,
-                    await httpResponseMessage.Content.ReadAsStringAsync());
-
             var result = await httpResponseMessage.Content.ReadAsStringAsync();
+
+            if (!httpResponseMessage.IsSuccessStatusCode) {
+                var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+            }
+
             var onboardingResponse = JsonConvert.DeserializeObject<OnboardResponse>(result);
 
             return onboardingResponse;

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/OnboardService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/OnboardService.cs
@@ -70,7 +70,7 @@ namespace Agrirouter.Impl.Service.Onboard
 
             if (!httpResponseMessage.IsSuccessStatusCode) {
                 var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
-                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.OnboardError);
             }
 
             var onboardingResponse = JsonConvert.DeserializeObject(result, typeof(OnboardResponse));
@@ -113,7 +113,7 @@ namespace Agrirouter.Impl.Service.Onboard
 
             if (!httpResponseMessage.IsSuccessStatusCode) {
                 var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
-                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.OnboardError);
             }
 
             var onboardingResponse = JsonConvert.DeserializeObject<OnboardResponse>(result);

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/RevokeService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/RevokeService.cs
@@ -37,7 +37,7 @@ namespace Agrirouter.Impl.Service.Onboard
         /// </summary>
         /// <param name="revokeParameters">The parameters for the revoke process.</param>
         /// <param name="privateKey">The private key.</param>
-        /// <exception cref="OnboardException">Will be thrown if the revoking was not successful.</exception>
+        /// <exception cref="RevokeException">Will be thrown if the revoking was not successful.</exception>
         public void Revoke(RevokeParameters revokeParameters, string privateKey)
         {
             var revokeRequest = new RevokeRequest
@@ -64,7 +64,7 @@ namespace Agrirouter.Impl.Service.Onboard
 
             if (!httpResponseMessage.IsSuccessStatusCode) {
                 var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(httpResponseMessage.Content.ReadAsStringAsync().Result);
-                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+                throw new RevokeException(httpResponseMessage.StatusCode, onboardErrorResponse.OnboardError);
             }
         }
 
@@ -73,7 +73,7 @@ namespace Agrirouter.Impl.Service.Onboard
         /// </summary>
         /// <param name="revokeParameters">The parameters for the revoke process.</param>
         /// <param name="privateKey">The private key.</param>
-        /// <exception cref="OnboardException">Will be thrown if the revoking was not successful.</exception>
+        /// <exception cref="RevokeException">Will be thrown if the revoking was not successful.</exception>
         public async Task RevokeAsync(RevokeParameters revokeParameters, string privateKey)
         {
             var revokeRequest = new RevokeRequest
@@ -100,7 +100,7 @@ namespace Agrirouter.Impl.Service.Onboard
 
             if (!httpResponseMessage.IsSuccessStatusCode) {
                 var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(await httpResponseMessage.Content.ReadAsStringAsync());
-                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+                throw new RevokeException(httpResponseMessage.StatusCode, onboardErrorResponse.OnboardError);
             }
         }
     }

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/RevokeService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/RevokeService.cs
@@ -37,7 +37,7 @@ namespace Agrirouter.Impl.Service.Onboard
         /// </summary>
         /// <param name="revokeParameters">The parameters for the revoke process.</param>
         /// <param name="privateKey">The private key.</param>
-        /// <exception cref="RevokeException">Will be thrown if the revoking was not successful.</exception>
+        /// <exception cref="OnboardException">Will be thrown if the revoking was not successful.</exception>
         public void Revoke(RevokeParameters revokeParameters, string privateKey)
         {
             var revokeRequest = new RevokeRequest
@@ -62,9 +62,10 @@ namespace Agrirouter.Impl.Service.Onboard
 
             var httpResponseMessage = _httpClient.SendAsync(httpRequestMessage).Result;
 
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                throw new RevokeException(httpResponseMessage.StatusCode,
-                    httpResponseMessage.Content.ReadAsStringAsync().Result);
+            if (!httpResponseMessage.IsSuccessStatusCode) {
+                var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(httpResponseMessage.Content.ReadAsStringAsync().Result);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+            }
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Agrirouter.Impl.Service.Onboard
         /// </summary>
         /// <param name="revokeParameters">The parameters for the revoke process.</param>
         /// <param name="privateKey">The private key.</param>
-        /// <exception cref="RevokeException">Will be thrown if the revoking was not successful.</exception>
+        /// <exception cref="OnboardException">Will be thrown if the revoking was not successful.</exception>
         public async Task RevokeAsync(RevokeParameters revokeParameters, string privateKey)
         {
             var revokeRequest = new RevokeRequest
@@ -97,9 +98,10 @@ namespace Agrirouter.Impl.Service.Onboard
 
             var httpResponseMessage = await _httpClient.SendAsync(httpRequestMessage);
 
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                throw new RevokeException(httpResponseMessage.StatusCode,
-                    await httpResponseMessage.Content.ReadAsStringAsync());
+            if (!httpResponseMessage.IsSuccessStatusCode) {
+                var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(await httpResponseMessage.Content.ReadAsStringAsync());
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+            }
         }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/SecuredOnboardingService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/SecuredOnboardingService.cs
@@ -68,12 +68,13 @@ namespace Agrirouter.Impl.Service.Onboard
                 SignatureService.XAgrirouterSignature(requestBody, privateKey));
 
             var httpResponseMessage = _httpClient.SendAsync(httpRequestMessage).Result;
-
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                throw new OnboardException(httpResponseMessage.StatusCode,
-                    httpResponseMessage.Content.ReadAsStringAsync().Result);
-
             var result = httpResponseMessage.Content.ReadAsStringAsync().Result;
+
+            if (!httpResponseMessage.IsSuccessStatusCode) {
+                var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+            }
+
             var onboardingResponse = JsonConvert.DeserializeObject(result, typeof(OnboardResponse));
             return onboardingResponse as OnboardResponse;
         }
@@ -113,12 +114,13 @@ namespace Agrirouter.Impl.Service.Onboard
                 SignatureService.XAgrirouterSignature(requestBody, privateKey));
 
             var httpResponseMessage = await _httpClient.SendAsync(httpRequestMessage);
-
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                throw new OnboardException(httpResponseMessage.StatusCode,
-                   await httpResponseMessage.Content.ReadAsStringAsync());
-
             var result = await httpResponseMessage.Content.ReadAsStringAsync();
+
+            if (!httpResponseMessage.IsSuccessStatusCode) {
+                var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+            }
+
             var onboardingResponse = JsonConvert.DeserializeObject< OnboardResponse>(result);
 
             return onboardingResponse;

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/SecuredOnboardingService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Onboard/SecuredOnboardingService.cs
@@ -72,7 +72,7 @@ namespace Agrirouter.Impl.Service.Onboard
 
             if (!httpResponseMessage.IsSuccessStatusCode) {
                 var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
-                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.OnboardError);
             }
 
             var onboardingResponse = JsonConvert.DeserializeObject(result, typeof(OnboardResponse));
@@ -118,7 +118,7 @@ namespace Agrirouter.Impl.Service.Onboard
 
             if (!httpResponseMessage.IsSuccessStatusCode) {
                 var onboardErrorResponse = JsonConvert.DeserializeObject<OnboardErrorResponse>(result);
-                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.onboardError);
+                throw new OnboardException(httpResponseMessage.StatusCode, onboardErrorResponse.OnboardError);
             }
 
             var onboardingResponse = JsonConvert.DeserializeObject< OnboardResponse>(result);

--- a/agrirouter-sdk-dotnet-standard-test/Service/Onboard/OnboardServiceTest.cs
+++ b/agrirouter-sdk-dotnet-standard-test/Service/Onboard/OnboardServiceTest.cs
@@ -37,7 +37,8 @@ namespace Agrirouter.Test.Service.Onboard
             };
 
 
-            Assert.Throws<OnboardException>(() => onboardingService.Onboard(parameters));
+            var exception = Assert.Throws<OnboardException>(() => onboardingService.Onboard(parameters));
+            Assert.Equal("0401", exception.Error.Code);
         }
 
         [Fact(Skip = "Will not run successfully without changing the registration code.")]

--- a/agrirouter-sdk-dotnet-standard-test/Service/Onboard/RevokeServiceTestForFarmingSoftware.cs
+++ b/agrirouter-sdk-dotnet-standard-test/Service/Onboard/RevokeServiceTestForFarmingSoftware.cs
@@ -48,7 +48,7 @@ namespace Agrirouter.Test.Service.Onboard
             var revokeService = new RevokeService(Environment, HttpClient);
             Action act = () => revokeService.Revoke(revokeParameters, Applications.FarmingSoftware.PrivateKey);
 
-            OnboardException exception = Assert.Throws<OnboardException>(act);
+            RevokeException exception = Assert.Throws<RevokeException>(act);
 
             Assert.Equal("0107", exception.Error.Code);
             Assert.Equal("Invalid signature", exception.Error.Message);

--- a/agrirouter-sdk-dotnet-standard-test/Service/Onboard/RevokeServiceTestForFarmingSoftware.cs
+++ b/agrirouter-sdk-dotnet-standard-test/Service/Onboard/RevokeServiceTestForFarmingSoftware.cs
@@ -6,6 +6,7 @@ using Agrirouter.Api.Service.Parameters;
 using Agrirouter.Impl.Service.Onboard;
 using Agrirouter.Test.Data;
 using Agrirouter.Test.Helper;
+using Serilog;
 using Xunit;
 
 namespace Agrirouter.Test.Service.Onboard
@@ -45,8 +46,12 @@ namespace Agrirouter.Test.Service.Onboard
             };
 
             var revokeService = new RevokeService(Environment, HttpClient);
-            Assert.Throws<RevokeException>(() =>
-                revokeService.Revoke(revokeParameters, Applications.FarmingSoftware.PrivateKey));
+            Action act = () => revokeService.Revoke(revokeParameters, Applications.FarmingSoftware.PrivateKey);
+
+            OnboardException exception = Assert.Throws<OnboardException>(act);
+
+            Assert.Equal("0107", exception.Error.Code);
+            Assert.Equal("Invalid signature", exception.Error.Message);
         }
     }
 }


### PR DESCRIPTION
Fixes #95, fixes #93. This PR parses server error response during onboarding and revoking processes and puts all the parsed information inside the thrown exception.

Notes:
  * this is a breaking change. But I can make it backward compatible with the current version if it's critical to maintain backward compatibility.
  * I'm not sure about the naming of classes `OnboardError` and `OnboardException` (they are created during both onboarding and revoking). If the server returns errors in the same format (`{error: {code, message, target, details}}`) in all the endpoints, one can rename these classes and reuse them in other places.