### PR TITLE
Throw exception if we failed to send an MQTT message

### DIFF
--- a/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotSendHttpMessageException.cs
+++ b/agrirouter-sdk-dotnet-standard-api/Exception/CouldNotSendHttpMessageException.cs
@@ -20,8 +20,8 @@ namespace Agrirouter.Api.Exception
             ErrorMessage = errorMessage;
         }
 
-        private HttpStatusCode StatusCode { get; }
+        public HttpStatusCode StatusCode { get; }
 
-        private string ErrorMessage { get; }
+        public string ErrorMessage { get; }
     }
 }

--- a/agrirouter-sdk-dotnet-standard-impl/Service/Common/MqttMessagingService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Common/MqttMessagingService.cs
@@ -9,6 +9,7 @@ using Agrirouter.Api.Service.Messaging;
 using Agrirouter.Api.Service.Parameters;
 using MQTTnet;
 using MQTTnet.Client;
+using MQTTnet.Client.Publishing;
 using Newtonsoft.Json;
 
 namespace Agrirouter.Impl.Service.Common
@@ -53,7 +54,11 @@ namespace Agrirouter.Impl.Service.Common
         public async Task<MessagingResult> SendAsync(MessagingParameters messagingParameters)
         {
             var mqttMessage = BuildMqttApplicationMessage(messagingParameters);
-            await _mqttClient.PublishAsync(mqttMessage, CancellationToken.None);
+            var response = await _mqttClient.PublishAsync(mqttMessage, CancellationToken.None);
+
+            if (response.ReasonCode != MqttClientPublishReasonCode.Success) {
+                throw new CouldNotSendMqttMessageException(response.ReasonCode, response.ReasonString);
+            }
 
             return new MessagingResultBuilder().WithApplicationMessageId(messagingParameters.ApplicationMessageId).Build();
         }


### PR DESCRIPTION
Fixes #94 . `MqttMessagingService` throws an `CouldNotSendMqttMessageException` if MQTTNet's MQTTClient returns an error.

Unfortunately, I couldn't test it properly because looks like MQTT onboarding responses in the repo are invalid (at least the only MQTT test `GivenValidCapabilitiesWhenSendingCapabilitiesMessageThenTheAgrirouterShouldSetTheCapabilities` fails).