### PR TITLE
Use correct method for getting memoryStream contents

### DIFF
--- a/agrirouter-sdk-dotnet-standard-impl/Service/Common/EncodeMessageService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Common/EncodeMessageService.cs
@@ -40,7 +40,7 @@ namespace Agrirouter.Impl.Service.Common
             using var memoryStream = new MemoryStream();
             Header(messageHeaderParameters).WriteDelimitedTo(memoryStream);
             PayloadWrapper(messagePayloadParameters).WriteDelimitedTo(memoryStream);
-            var encodedMessage = Convert.ToBase64String(memoryStream.GetBuffer());
+            var encodedMessage = Convert.ToBase64String(memoryStream.ToArray());
 
             Log.Debug("Finished encoding of the message.");
             return encodedMessage;


### PR DESCRIPTION
Using `MemoryStream.GetBuffer()` can return allocated but unused bytes from the buffer:
https://docs.microsoft.com/en-us/dotnet/api/system.io.memorystream.getbuffer?view=net-6.0#remarks

`ToArray()` is the correct method to use.