### PR TITLE
Added the option to modify the timestamp to send

### DIFF
--- a/agrirouter-sdk-dotnet-standard-impl/Service/Common/UtcDataService.cs
+++ b/agrirouter-sdk-dotnet-standard-impl/Service/Common/UtcDataService.cs
@@ -9,6 +9,21 @@ namespace Agrirouter.Impl.Service.Common
     public class UtcDataService
     {
         /// <summary>
+        ///     Overrides the the computer time and instead allways return the given time.
+        /// </summary>
+        public static DateTime? UtcNowOverride { get; set; } = null;
+
+        /// <summary>
+        ///     Adds an offset to the computer time.
+        /// </summary>
+        public static TimeSpan UtcNowOffset { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        ///     Gets an adjusted UtcNow value that uses UtcNowOverride and UtcNowOffset to calculate the time to return.
+        /// </summary>
+        public static DateTime UtcNow => UtcNowOverride ?? DateTime.UtcNow.Add(UtcNowOffset);
+
+        /// <summary>
         ///     Delivering the current time zone.
         /// </summary>
         public static string TimeZone =>
@@ -18,7 +33,7 @@ namespace Agrirouter.Impl.Service.Common
         /// <summary>
         ///     Delivering the current date using a valid AR format.
         /// </summary>
-        public static string Now => DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'");
+        public static string Now => UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'");
 
         /// <summary>
         ///     Delivering the current date using a timestamp format.
@@ -26,7 +41,7 @@ namespace Agrirouter.Impl.Service.Common
         /// <returns></returns>
         public static Timestamp NowAsTimestamp()
         {
-            var timeSpan = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0);
+            var timeSpan = UtcNow - new DateTime(1970, 1, 1, 0, 0, 0);
             return new Timestamp {Seconds = (long) timeSpan.TotalSeconds, Nanos = 1000000};
         }
 
@@ -37,7 +52,7 @@ namespace Agrirouter.Impl.Service.Common
         /// <returns>-</returns>
         public static Timestamp Timestamp(long offset)
         {
-            var timeSpan = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0);
+            var timeSpan = UtcNow - new DateTime(1970, 1, 1, 0, 0, 0);
             return new Timestamp {Seconds = (long) timeSpan.TotalSeconds - offset, Nanos = 1000000};
         }
 
@@ -47,7 +62,7 @@ namespace Agrirouter.Impl.Service.Common
         /// <returns>-</returns>
         public static string NowAsUnixTimestamp()
         {
-            var unixTimestamp = (int) DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+            var unixTimestamp = (int) UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
             return unixTimestamp.ToString();
         }
     }


### PR DESCRIPTION
Added the option to modify the timestamp to send if the local time is ahead of server time. 

This is similar to the fix already present in the agrirouter-postman-tools: https://github.com/DKE-Data/agrirouter-postman-tools/blob/a13bff2743ceed3e464a4c9d0d4520f460501199/postman/OnBoarding%20FMIS%20%26%20Telemetry.postman_collection.json#L50