### PR TITLE
Feature/happy path testing for documentation

### DIFF
--- a/agrirouter-sdk-dotnet-standard-test/Documentation/OnboardingForTelemetryConnectionTest.cs
+++ b/agrirouter-sdk-dotnet-standard-test/Documentation/OnboardingForTelemetryConnectionTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net.Http;
+using Agrirouter.Api.Definitions;
+using Agrirouter.Api.Service.Parameters;
+using Agrirouter.Impl.Service.Common;
+using Agrirouter.Impl.Service.Onboard;
+using Agrirouter.Test.Data;
+using Agrirouter.Test.Helper;
+using Agrirouter.Test.Service;
+using Xunit;
+
+namespace Agrirouter.Test.Documentation;
+
+public class OnboardingForTelemetryConnectionTest : AbstractIntegrationTestForCommunicationUnits
+{
+    private static readonly UtcDataService UtcDataService = new();
+    private static readonly HttpClient HttpClient = HttpClientFactory.HttpClient();
+
+    [Fact(Skip = "Will not run successfully without changing the registration code.")]
+    public void GivenValidRequestTokenWhenOnboardingThenThereShouldBeAValidResponse()
+    {
+        // [1] Create onboarding parameters
+        // ============================================================
+        // Define the parameters used for onboarding, please be aware that the registration code needs
+        // to be replaced with an actual code to run the test case.
+        var parameters = new OnboardParameters
+        {
+            Uuid = Guid.NewGuid().ToString(),
+            ApplicationId = Applications.CommunicationUnit.ApplicationId,
+            ApplicationType = ApplicationTypeDefinitions.Application,
+            CertificationType = CertificationTypeDefinition.P12,
+            GatewayId = GatewayTypeDefinition.Mqtt,
+            RegistrationCode = "REPLACE_ME_WITH_ACTUAL_CODE",
+            CertificationVersionId = Applications.CommunicationUnit.CertificationVersionId
+        };
+
+        // [2] Onboard the new telemetry connection
+        // ============================================================
+        // Use the onboarding service to onboard the new telemetry connection.
+        var onboardService = new OnboardService(Environment, UtcDataService, HttpClient);
+        var onboardResponse = onboardService.Onboard(parameters);
+
+        // [3] Validate the onboarding response
+        // ============================================================
+        // Check if the onboarding response contains all necessary information. This is just necessary within the tests, but not
+        // needed in production code.
+        Assert.NotEmpty(onboardResponse.DeviceAlternateId);
+        Assert.NotEmpty(onboardResponse.SensorAlternateId);
+        Assert.NotEmpty(onboardResponse.CapabilityAlternateId);
+        Assert.NotEmpty(onboardResponse.Authentication.Certificate);
+        Assert.NotEmpty(onboardResponse.Authentication.Secret);
+        Assert.NotEmpty(onboardResponse.Authentication.Type);
+        Assert.NotEmpty(onboardResponse.ConnectionCriteria.Commands);
+        Assert.NotEmpty(onboardResponse.ConnectionCriteria.Measures);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new integration test to validate the onboarding process for telemetry connections in the `agrirouter-sdk-dotnet-standard-test` project. The test is designed to ensure that the onboarding process produces a valid response, though it is currently skipped due to requiring a valid registration code.

### Addition of a new test for onboarding telemetry connections:
* `agrirouter-sdk-dotnet-standard-test/Documentation/OnboardingForTelemetryConnectionTest.cs`:
  - Added a new test class, `OnboardingForTelemetryConnectionTest`, which extends `AbstractIntegrationTestForCommunicationUnits`.
  - Implemented the `GivenValidRequestTokenWhenOnboardingThenThereShouldBeAValidResponse` test method to:
    1. Define onboarding parameters, including a placeholder for the registration code.
    2. Use the `OnboardService` to onboard a new telemetry connection.
    3. Validate the onboarding response by asserting that all necessary fields are populated.
  - Marked the test with `[Fact(Skip = "...")]` to indicate that it requires manual intervention to run successfully.This commit introduces a new integration test, `OnboardingForTelemetryConnectionTest`, to validate onboarding functionality for telemetry connections. The test is currently skipped due to the need for a valid registration code, but it verifies the onboarding response structure and ensures all necessary fields are populated.